### PR TITLE
Feature: List operator in `bazel-credential-helper`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ go.work.sum
 .env
 
 # Default program output
-docker-credential-artifactory
+docker-credential-jfrog
+bazel-credential-jfrog

--- a/cmd/bazel/handler.go
+++ b/cmd/bazel/handler.go
@@ -58,3 +58,18 @@ func (h ArtifactoryCredentialProvider) Get(request bazel.GetCredentialsRequest) 
 	log.Fatalln("not logged into", serverURL, "from JFrog CLI")
 	return nil, errors.ErrUnsupported
 }
+
+func (h ArtifactoryCredentialProvider) List() (bazel.ListCredentialsResponse, error) {
+	serverDetailList, err := config.GetAllServersConfigs()
+	if err != nil {
+		log.Fatalln("unable to retrieve JFrog server configs:", err)
+		return nil, err
+	}
+
+	response := make(bazel.ListCredentialsResponse)
+	for _, serverDetails := range serverDetailList {
+		response[serverDetails.Url] = serverDetails.Url
+	}
+
+	return response, nil
+}

--- a/internal/bazel/server.go
+++ b/internal/bazel/server.go
@@ -21,7 +21,7 @@ func Serve(provider BazelCredentialProvider) {
 
 		res, err := provider.Get(request)
 		if err != nil {
-			log.Fatalln("unable to process 'get' request:", request, err)
+			log.Fatalln("unable to process 'get' subcommand:", request, err)
 		}
 
 		enc := json.NewEncoder(os.Stdout)
@@ -29,9 +29,19 @@ func Serve(provider BazelCredentialProvider) {
 		if err != nil {
 			log.Fatalln("unable to encode 'get' response:", err)
 		}
+	case "list":
+		res, err := provider.List()
+		if err != nil {
+			log.Fatalln("unable to process 'list' subcommand:", err)
+		}
 
+		enc := json.NewEncoder(os.Stdout)
+		err = enc.Encode(res)
+		if err != nil {
+			log.Fatalln("unable to encode 'list' response:", err)
+		}
 	default:
-		fmt.Println("expected <get> subcommand")
+		fmt.Println("expected <get|list> subcommand")
 		os.Exit(1)
 	}
 }

--- a/internal/bazel/spec.go
+++ b/internal/bazel/spec.go
@@ -11,6 +11,9 @@ type GetCredentialsReponse struct {
 	Headers map[string][]string `json:"headers,omitempty"`
 }
 
+type ListCredentialsResponse = map[string]string
+
 type BazelCredentialProvider interface {
 	Get(request GetCredentialsRequest) (*GetCredentialsReponse, error)
+	List() (ListCredentialsResponse, error)
 }


### PR DESCRIPTION
Adds a `list` subcommand to `bazel-credential-helper` which just dumps the list of currently logged-in URIs, emulating the output of `docker-credential-helper`.

This is not an officially supported subcommand in bazel's credential helper spec, but it is useful for debugging.

```
$ ./bazel-credential-jfrog list
{"https://foobar.jfrog.io/":"https://foobar.jfrog.io/"}
```